### PR TITLE
feat(compose): run Cast Service303 endpoint

### DIFF
--- a/docker-compose.relay.yml
+++ b/docker-compose.relay.yml
@@ -1,5 +1,6 @@
 # RELAY Gateway - CDN Cache with DNS forwarding
-# Extension of docker-compose.yml: relay cache, Traffic Router/Monitor, AMT, MoQ, multicast.
+# Extension of docker-compose.yml: relay cache, Cast, Traffic Router/Monitor,
+# AMT, MoQ, multicast.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.relay.yml --profile <backend> up
@@ -68,6 +69,11 @@ services:
     networks:
       - default
       - relay
+    # Cast uses host networking for multicast and therefore is not present in
+    # Docker's bridge DNS. Keep the canonical service-registry name (`cast`)
+    # resolvable from blockcastd without adding a proxy or scrape path.
+    extra_hosts:
+      - "cast:host-gateway"
 
   # When relay cache is running, it aliases as "control-proxy" on the relay network.
   # When relay is NOT enabled (standalone control-proxy mode), the base control-proxy
@@ -282,6 +288,38 @@ services:
   # ==========================================================================
   # MANAGED RELAY SERVICES
   # ==========================================================================
+
+  # Cast - publisher orchestrator and native Magma Service303 endpoint.
+  # Host networking is required for the multicast egress path. blockcastd
+  # reaches GetMetrics at cast:50054 through the host-gateway alias above.
+  cast:
+    <<: *managed
+    image: ${DOCKER_REGISTRY:-blockcast/}cast:${IMAGE_VERSION:-stable}
+    container_name: cast
+    hostname: cast
+    network_mode: host
+    command: ["publish"]
+    volumes:
+      - ${HOME}/.blockcast/certs:/var/opt/magma/certs:ro
+    environment:
+      CAST_TO_URL: ${TO_URL:-https://to.infra.blockcast.net}
+      CAST_TO_CERT: ${CAST_TO_CERT:-/var/opt/magma/certs/gateway.crt}
+      CAST_TO_KEY: ${CAST_TO_KEY:-/var/opt/magma/certs/gateway.key}
+      # The gateway's TO endpoint is terminated by the internal ATS
+      # certificate in the default deployment; match the K8s Cast contract.
+      # Operators with a trusted TO CA can set CAST_TO_INSECURE=false.
+      CAST_TO_INSECURE: ${CAST_TO_INSECURE:-true}
+      CAST_TLS_CERT: ${CAST_TLS_CERT:-/var/opt/magma/certs/gateway.crt}
+      CAST_TLS_KEY: ${CAST_TLS_KEY:-/var/opt/magma/certs/gateway.key}
+      CAST_HOST_NETWORK: "true"
+      CAST_SERVICE303_LISTEN_ADDR: ${CAST_SERVICE303_LISTEN_ADDR:-0.0.0.0:50054}
+      CAST_RESTART_ON_FAILURE: ${CAST_RESTART_ON_FAILURE:-true}
+      CAST_RESTART_DELAY: ${CAST_RESTART_DELAY:-5}
+      CAST_MAX_RESTARTS: ${CAST_MAX_RESTARTS:-0}
+      RUST_LOG: ${RUST_LOG:-info,cast=info}
+    labels:
+      <<: *labels
+      service.type: "cast"
 
   # Traffic Router - Authoritative DNS for *.bcast.id
   # Port 53: Public DNS (NO mTLS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 #   docker compose up -d                    # Start core services
 #   docker compose --profile managed up -d  # Start all services (for testing)
 #
-# For relay services (cache, TR, TM, AMT, MoQ, multicast), see docker-compose.relay.yml
+# For relay services (cache, Cast, TR, TM, AMT, MoQ, multicast), see docker-compose.relay.yml
 
 # Bound container log growth so writable layers don't fill /. Uses docker's
 # built-in "local" driver — chosen over `journald` so this works on hosts
@@ -79,7 +79,7 @@ services:
       managed: "true"
       service.type: "beacond"
 
-  # Dynamic relay services (cache, TR, TM, AMT, MoQ, multicast) are defined
+  # Dynamic relay services (cache, Cast, TR, TM, AMT, MoQ, multicast) are defined
   # in docker-compose.relay.yml with profile-based backend selection.
   # Use: docker compose -f docker-compose.yml -f docker-compose.relay.yml --profile <backend> up
 


### PR DESCRIPTION
## Summary

Add Cast as a managed compose service and make its native Service303 endpoint reachable by blockcastd.

- Run `blockcast/cast:${IMAGE_VERSION:-stable}` with host networking for multicast.
- Set `CAST_SERVICE303_LISTEN_ADDR=0.0.0.0:50054` and mount the gateway certificates/Traffic Ops credentials used by Cast.
- Label the service `service.type: cast` so blockcastd can manage and dependency-gate it.
- Add `cast:host-gateway` to blockcastd because a host-networked Cast process is not present in bridge-network DNS.

The matching `develop`-base change is in [the develop PR](https://github.com/Blockcast/beacon-docker-compose/pull/new/codex/cast-service303-metrics-develop). This depends on the Cast and Magma changes in [#2280](https://github.com/Blockcast/pim-multicast-gateway/pull/2280) and [#1759](https://github.com/Blockcast/magma/pull/1759).

## Validation

- `docker compose --profile managed config --quiet`
- `git diff --check`
